### PR TITLE
Fix Vercel config path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,5 @@
   "buildCommand": "turbo run build",
   "ignoreCommand": "turbo run lint",
   "installCommand": "yarn install",
-  "outputDirectory": "./packages/landing/.next"
+  "outputDirectory": "./apps/landing/.next"
 } 


### PR DESCRIPTION
## Summary
- fix output directory in `vercel.json`

## Testing
- `yarn lint` *(fails: fetch failed)*

## Summary by Sourcery

Bug Fixes:
- Correct output directory path in Vercel config to ensure deployments use the intended build output