### PR TITLE
Revert "Fix Vercel config path"

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,5 @@
   "buildCommand": "turbo run build",
   "ignoreCommand": "turbo run lint",
   "installCommand": "yarn install",
-  "outputDirectory": "./apps/landing/.next"
+  "outputDirectory": "./packages/landing/.next"
 } 


### PR DESCRIPTION
Reverts foxy17/Portfolio-v2#7

## Summary by Sourcery

Chores:
- Restore vercel.json to its pre-fix state by reverting the config path adjustment