### PR TITLE
refactor(landing): extract ProjectShowcase modal controller, focus trap, carousel

### DIFF
--- a/apps/landing/src/components/Stuff/ProjectImageCarousel.tsx
+++ b/apps/landing/src/components/Stuff/ProjectImageCarousel.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Image from 'next/image';
+import cn from 'classnames';
+import { FiArrowLeft, FiArrowRight } from 'react-icons/fi';
+
+type ProjectImage = {
+  src: string;
+  alt: string;
+};
+
+type Props = {
+  images: ProjectImage[];
+  imageIndex: number;
+  onNext: () => void;
+  onPrevious: () => void;
+  onSelect: (index: number) => void;
+};
+
+export function ProjectImageCarousel({ images, imageIndex, onNext, onPrevious, onSelect }: Props) {
+  const activeImage = images[imageIndex];
+  const hasMultipleImages = images.length > 1;
+
+  return (
+    <div className="mx-auto mb-6 w-full max-w-md overflow-hidden rounded-xl border-2 border-black bg-white dark:border-white dark:bg-dark-grey">
+      <div className="relative aspect-[16/10] w-full">
+        <Image
+          key={activeImage.src}
+          src={activeImage.src}
+          alt={activeImage.alt}
+          fill
+          sizes="(max-width: 768px) 100vw, 768px"
+          className="object-cover transition-opacity duration-300"
+          priority
+        />
+        {hasMultipleImages && (
+          <div className="absolute inset-x-3 top-1/2 flex -translate-y-1/2 items-center justify-between">
+            <button
+              type="button"
+              onClick={onPrevious}
+              className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-black bg-beige text-black transition hover:-translate-y-0.5 dark:border-white dark:bg-dark-black dark:text-white"
+              aria-label="Previous project image"
+            >
+              <FiArrowLeft />
+            </button>
+            <button
+              type="button"
+              onClick={onNext}
+              className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-black bg-beige text-black transition hover:-translate-y-0.5 dark:border-white dark:bg-dark-black dark:text-white"
+              aria-label="Next project image"
+            >
+              <FiArrowRight />
+            </button>
+          </div>
+        )}
+      </div>
+      {hasMultipleImages && (
+        <div className="flex items-center justify-center gap-2 border-t-2 border-black px-4 py-3 dark:border-white">
+          {images.map((image, index) => (
+            <button
+              key={image.src}
+              type="button"
+              onClick={() => onSelect(index)}
+              className={cn(
+                'h-2.5 rounded-full transition-all',
+                index === imageIndex
+                  ? 'w-8 bg-flat-purple dark:bg-flat-yellow'
+                  : 'w-2.5 bg-gray-300 dark:bg-gray-600',
+              )}
+              aria-label={`Show project image ${index + 1}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/landing/src/components/Stuff/ProjectShowcase.tsx
+++ b/apps/landing/src/components/Stuff/ProjectShowcase.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Image from 'next/image';
+import React, { useEffect, useMemo, useRef } from 'react';
 import Link from 'next/link';
 import cn from 'classnames';
 import {
-  FiArrowLeft,
   FiArrowRight,
   FiArrowUpRight,
   FiExternalLink,
@@ -13,12 +11,16 @@ import {
   FiX,
 } from 'react-icons/fi';
 
+import { ProjectImageCarousel } from '~/components/Stuff/ProjectImageCarousel';
+import { useFocusTrap } from '~/components/Stuff/useFocusTrap';
+import { useProjectModalController } from '~/components/Stuff/useProjectModalController';
+
 type ProjectImage = {
   src: string;
   alt: string;
 };
 
-type Project = {
+export type Project = {
   title: string;
   description: string;
   why: string;
@@ -175,6 +177,7 @@ function ProjectModal({
 }) {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
+  const handleKeyDown = useFocusTrap(modalRef);
 
   useEffect(() => {
     if (project && isVisible) {
@@ -182,33 +185,8 @@ function ProjectModal({
     }
   }, [project, isVisible]);
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Tab') return;
-
-    const focusableElements = modalRef.current?.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    );
-    if (!focusableElements?.length) return;
-
-    const firstElement = focusableElements[0];
-    const lastElement = focusableElements[focusableElements.length - 1];
-
-    if (event.shiftKey && document.activeElement === firstElement) {
-      event.preventDefault();
-      lastElement.focus();
-      return;
-    }
-
-    if (!event.shiftKey && document.activeElement === lastElement) {
-      event.preventDefault();
-      firstElement.focus();
-    }
-  };
-
   if (!project) return null;
 
-  const activeImage = project.images[imageIndex];
-  const hasMultipleImages = project.images.length > 1;
   const isLiveExternal = project.liveUrl?.startsWith('http');
 
   return (
@@ -262,57 +240,13 @@ function ProjectModal({
             </button>
           </div>
 
-          <div className="mx-auto mb-6 w-full max-w-md overflow-hidden rounded-xl border-2 border-black bg-white dark:border-white dark:bg-dark-grey">
-            <div className="relative aspect-[16/10] w-full">
-              <Image
-                key={activeImage.src}
-                src={activeImage.src}
-                alt={activeImage.alt}
-                fill
-                sizes="(max-width: 768px) 100vw, 768px"
-                className="object-cover transition-opacity duration-300"
-                priority
-              />
-              {hasMultipleImages && (
-                <div className="absolute inset-x-3 top-1/2 flex -translate-y-1/2 items-center justify-between">
-                  <button
-                    type="button"
-                    onClick={onPreviousImage}
-                    className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-black bg-beige text-black transition hover:-translate-y-0.5 dark:border-white dark:bg-dark-black dark:text-white"
-                    aria-label="Previous project image"
-                  >
-                    <FiArrowLeft />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={onNextImage}
-                    className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-black bg-beige text-black transition hover:-translate-y-0.5 dark:border-white dark:bg-dark-black dark:text-white"
-                    aria-label="Next project image"
-                  >
-                    <FiArrowRight />
-                  </button>
-                </div>
-              )}
-            </div>
-            {hasMultipleImages && (
-              <div className="flex items-center justify-center gap-2 border-t-2 border-black px-4 py-3 dark:border-white">
-                {project.images.map((image, index) => (
-                  <button
-                    key={image.src}
-                    type="button"
-                    onClick={() => onSelectImage(index)}
-                    className={cn(
-                      'h-2.5 rounded-full transition-all',
-                      index === imageIndex
-                        ? 'w-8 bg-flat-purple dark:bg-flat-yellow'
-                        : 'w-2.5 bg-gray-300 dark:bg-gray-600',
-                    )}
-                    aria-label={`Show project image ${index + 1}`}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
+          <ProjectImageCarousel
+            images={project.images}
+            imageIndex={imageIndex}
+            onNext={onNextImage}
+            onPrevious={onPreviousImage}
+            onSelect={onSelectImage}
+          />
 
           <div className="mb-6 grid gap-4">
             <section>
@@ -398,69 +332,15 @@ function ProjectModal({
 }
 
 export default function ProjectShowcase() {
-  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
-  const [selectedStack, setSelectedStack] = useState('All');
-  const [isVisible, setIsVisible] = useState(false);
-  const [imageIndex, setImageIndex] = useState(0);
-  const activeTriggerRef = useRef<HTMLElement | null>(null);
+  const [selectedStack, setSelectedStack] = React.useState('All');
+  const { selectedItem, isVisible, imageIndex, setImageIndex, open, close, nextImage, previousImage } =
+    useProjectModalController<Project>();
 
   const filteredProjects = useMemo(() => {
     if (selectedStack === 'All') return projects;
 
     return projects.filter((project) => project.stack.includes(selectedStack));
   }, [selectedStack]);
-
-  const closeProject = useCallback(() => {
-    setIsVisible(false);
-    window.setTimeout(() => {
-      setSelectedProject(null);
-      activeTriggerRef.current?.focus();
-    }, 180);
-  }, []);
-
-  useEffect(() => {
-    if (!selectedProject) return undefined;
-
-    const showTimer = window.setTimeout(() => {
-      setIsVisible(true);
-    }, 20);
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        closeProject();
-      }
-    };
-
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    window.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      window.clearTimeout(showTimer);
-      document.body.style.overflow = previousOverflow;
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [closeProject, selectedProject]);
-
-  const openProject = (project: Project) => {
-    activeTriggerRef.current = document.activeElement as HTMLElement | null;
-    setImageIndex(0);
-    setSelectedProject(project);
-  };
-
-  const nextImage = () => {
-    if (!selectedProject) return;
-    setImageIndex((currentIndex) =>
-      currentIndex === selectedProject.images.length - 1 ? 0 : currentIndex + 1,
-    );
-  };
-
-  const previousImage = () => {
-    if (!selectedProject) return;
-    setImageIndex((currentIndex) =>
-      currentIndex === 0 ? selectedProject.images.length - 1 : currentIndex - 1,
-    );
-  };
 
   return (
     <>
@@ -507,17 +387,17 @@ export default function ProjectShowcase() {
           <ProjectCard
             key={project.title}
             project={project}
-            onOpen={openProject}
+            onOpen={open}
           />
         ))}
       </div>
       <ProjectModal
-        project={selectedProject}
+        project={selectedItem}
         imageIndex={imageIndex}
         isVisible={isVisible}
-        onClose={closeProject}
-        onNextImage={nextImage}
-        onPreviousImage={previousImage}
+        onClose={close}
+        onNextImage={() => nextImage(selectedItem?.images.length ?? 0)}
+        onPreviousImage={() => previousImage(selectedItem?.images.length ?? 0)}
         onSelectImage={setImageIndex}
       />
     </>

--- a/apps/landing/src/components/Stuff/useFocusTrap.ts
+++ b/apps/landing/src/components/Stuff/useFocusTrap.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import type React from 'react';
+
+export function useFocusTrap(containerRef: React.RefObject<HTMLElement | null>) {
+  return useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key !== 'Tab' || !containerRef.current) return;
+
+      const focusable = containerRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (!focusable.length) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    },
+    [containerRef],
+  );
+}

--- a/apps/landing/src/components/Stuff/useProjectModalController.ts
+++ b/apps/landing/src/components/Stuff/useProjectModalController.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function useProjectModalController<T>() {
+  const [selectedItem, setSelectedItem] = useState<T | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const [imageIndex, setImageIndex] = useState(0);
+  const activeTriggerRef = useRef<HTMLElement | null>(null);
+
+  const open = (item: T) => {
+    activeTriggerRef.current = document.activeElement as HTMLElement | null;
+    setImageIndex(0);
+    setSelectedItem(item);
+  };
+
+  const close = useCallback(() => {
+    setIsVisible(false);
+    window.setTimeout(() => {
+      setSelectedItem(null);
+      activeTriggerRef.current?.focus();
+    }, 180);
+  }, []);
+
+  useEffect(() => {
+    if (!selectedItem) return undefined;
+
+    const showTimer = window.setTimeout(() => setIsVisible(true), 20);
+    const previousOverflow = document.body.style.overflow;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') close();
+    };
+    document.body.style.overflow = 'hidden';
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.clearTimeout(showTimer);
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [close, selectedItem]);
+
+  const nextImage = (imagesLength: number) =>
+    setImageIndex((i) => (i === imagesLength - 1 ? 0 : i + 1));
+
+  const previousImage = (imagesLength: number) =>
+    setImageIndex((i) => (i === 0 ? imagesLength - 1 : i - 1));
+
+  return { selectedItem, isVisible, imageIndex, setImageIndex, open, close, nextImage, previousImage };
+}


### PR DESCRIPTION
## Summary
Addresses Sourcery complexity feedback on PR #13. Pure refactor — no UX change.
- Extract `useProjectModalController` (timing, scroll lock, escape, focus restore)
- Extract `useFocusTrap` (Tab cycling inside modal)
- Extract `ProjectImageCarousel` component

Stacked on top of #13. Merge #13 first.

## Test plan
- [ ] /stuff opens, project card click opens modal, animations smooth
- [ ] Escape closes modal, focus returns to triggering card
- [ ] Tab/Shift+Tab cycles inside modal only
- [ ] Body scroll locks while modal open
- [ ] Carousel arrows + indicator dots work, wrap at ends
- [ ] Internal liveUrl shows arrow icon, external shows external-link icon (preserved)

## Summary by Sourcery

Refactor the Stuff project showcase modal to extract reusable hooks and components for modal control, focus management, and image carousel behavior.

Enhancements:
- Extract a generic useProjectModalController hook to manage modal selection, visibility, image index, scroll locking, and escape handling.
- Extract a reusable useFocusTrap hook to constrain keyboard focus within the modal.
- Extract a ProjectImageCarousel component to encapsulate image navigation UI and logic in the project modal.
- Export the Project type from ProjectShowcase for reuse with the new controller hook.