### PR TITLE
fix(blog): improve mobile layout — wider content, smaller hero, cleaner nav

### DIFF
--- a/apps/blog/src/components/Header.astro
+++ b/apps/blog/src/components/Header.astro
@@ -6,7 +6,7 @@ import { SITE_TITLE } from '../consts';
 ---
 
 <header class="bg-beige dark:bg-dark-black text-gray-700 dark:text-beige">
-  <div class="flex flex-col justify-center px-8">
+  <div class="flex flex-col justify-center px-3 sm:px-8">
     <nav class="flex items-center justify-between w-full relative max-w-4xl border-gray-200 dark:border-gray-700 mx-auto pt-8 pb-8 sm:pb-[72px] text-base leading-normal font-['Atkinson',sans-serif] text-gray-900 bg-beige bg-opacity-60 dark:bg-dark-black dark:text-beige">
       <a href="#skip" class="skip-nav">Skip to content</a>
       <div class="ml-[-0.60rem]">

--- a/apps/blog/src/layouts/BlogPost.astro
+++ b/apps/blog/src/layouts/BlogPost.astro
@@ -51,9 +51,9 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 
 	<body>
 		<Header />
-		<main id="skip" class="w-[calc(100%-2em)] max-w-full m-0">
+		<main id="skip" class="w-full max-w-full m-0 p-0">
 			<article>
-				<div class="w-[720px] max-w-[calc(100%-2em)] mx-auto">
+				<div class="w-full max-w-[720px] mx-auto px-3 sm:px-4">
 					{
 						heroImage && (
 							<Image
@@ -70,7 +70,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 						)
 					}
 				</div>
-				<div class="prose dark:prose-invert w-[720px] max-w-[calc(100%-2em)] mx-auto p-4 text-gray-700 dark:text-beige">
+				<div class="prose dark:prose-invert w-full max-w-[720px] mx-auto px-3 py-4 sm:px-4 text-gray-700 dark:text-beige">
 					<div class="mb-4 py-4 text-center">
 						<div class="mb-2 text-gray-500 dark:text-beige flex items-center justify-center gap-2 flex-wrap">
 							<FormattedDate date={pubDate} />
@@ -134,7 +134,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 
 					{(prev || next) && (
 						<nav
-							class="not-prose mt-8 pt-6 border-t border-blog-border dark:border-blog-dark-border grid grid-cols-2 gap-4"
+							class="not-prose mt-8 pt-6 border-t border-blog-border dark:border-blog-dark-border flex flex-col gap-4 sm:grid sm:grid-cols-2"
 							aria-label="Post navigation"
 						>
 							{prev ? (
@@ -153,7 +153,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 							{next ? (
 								<a
 									href={`/${next.id}/`}
-									class="block text-right text-gray-700 dark:text-beige no-underline hover:text-flat-blue dark:hover:text-flat-blue"
+									class="block text-left sm:text-right text-gray-700 dark:text-beige no-underline hover:text-flat-blue dark:hover:text-flat-blue"
 								>
 									<span class="block text-xs text-gray-500 dark:text-gray-400">
 										Next →

--- a/apps/blog/src/styles/global.css
+++ b/apps/blog/src/styles/global.css
@@ -48,9 +48,24 @@
     body {
       @apply text-lg;
     }
-    
+
     main {
-      @apply p-4;
+      @apply px-3 py-8;
+    }
+
+    .prose h1 {
+      font-size: 2rem;
+      line-height: 1.15;
+    }
+
+    .prose h2 {
+      font-size: 1.5rem;
+      line-height: 1.25;
+    }
+
+    .prose h3 {
+      font-size: 1.25rem;
+      line-height: 1.3;
     }
   }
 }


### PR DESCRIPTION
Mobile blog post pages had ~64px of compounded horizontal margin (main + inner div each subtracting 2em) plus a 3rem h1 that wrapped poorly. Swap the double calc(100%-2em) wrappers for a single max-w-[720px] + px-3 container, scale prose h1/h2/h3 down on small screens, tighten the header padding, and stack the prev/next nav so a lone "Next" link no longer gets shoved to the right column.

https://claude.ai/code/session_0187uP14385zxQbcHk4bz1Dx

## Summary by Sourcery

Improve mobile blog post layout for better readability and navigation.

Bug Fixes:
- Prevent single next-link navigation from being misaligned on mobile by stacking prev/next links vertically on small screens.

Enhancements:
- Adjust blog post content container widths and padding to reduce excessive horizontal margins and better fit smaller screens.
- Reduce heading sizes within prose on small viewports to avoid awkward wrapping and improve text hierarchy.
- Tighten blog header padding on mobile for a more compact layout.