### PR TITLE
Fix Keystatic GitHub-mode dashboard in the monorepo

### DIFF
--- a/apps/blog/keystatic.config.ts
+++ b/apps/blog/keystatic.config.ts
@@ -1,12 +1,26 @@
 import { config, fields, collection, singleton } from '@keystatic/core';
 
-// Local filesystem in dev (edits write straight to ./src/content), GitHub in
-// production so the deployed /keystatic dashboard commits drafts + posts to the
-// repo. GitHub mode needs the KEYSTATIC_* env vars (see apps/blog/.env.example);
-// connect the GitHub App once via the deployed dashboard to generate them.
-const storage = import.meta.env.DEV
-	? ({ kind: 'local' } as const)
-	: ({ kind: 'github', repo: 'foxy17/Portfolio-v2' } as const);
+// Storage resolution (must match on server + client, so read it from
+// import.meta.env which Astro exposes to both):
+// - production build -> GitHub (the deployed /keystatic commits to the repo)
+// - local dev        -> local filesystem (edits write straight to ./src/content)
+// - PUBLIC_KEYSTATIC_STORAGE=github -> force GitHub mode anywhere, including
+//   localhost. Needed once to run the "Connect to GitHub" app-creation wizard,
+//   which Keystatic only renders on localhost — a deployed domain just shows a
+//   "Log in with GitHub" button that dead-ends until the KEYSTATIC_* env exist.
+const storageKind =
+	import.meta.env.PUBLIC_KEYSTATIC_STORAGE ??
+	(import.meta.env.DEV ? 'local' : 'github');
+const storage =
+	storageKind === 'github'
+		? ({ kind: 'github', repo: 'foxy17/Portfolio-v2' } as const)
+		: ({ kind: 'local' } as const);
+
+// In a monorepo, GitHub storage reads paths relative to the repo root, while
+// local storage reads them relative to cwd (apps/blog). Prefix every
+// repo-relative path with the app dir in GitHub mode so the dashboard finds
+// content; leave it empty locally. publicPath URLs are unaffected.
+const repoDir = storageKind === 'github' ? 'apps/blog/' : '';
 
 export default config({
 	storage,
@@ -17,7 +31,7 @@ export default config({
 		posts: collection({
 			label: 'Blog posts',
 			slugField: 'title',
-			path: 'src/content/blog/*',
+			path: `${repoDir}src/content/blog/*`,
 			format: { contentField: 'content' },
 			entryLayout: 'content',
 			columns: ['title', 'pubDate'],
@@ -42,14 +56,14 @@ export default config({
 				updatedDate: fields.date({ label: 'Updated date' }),
 				heroImage: fields.image({
 					label: 'Hero image',
-					directory: 'public/heroes',
+					directory: `${repoDir}public/heroes`,
 					publicPath: '/heroes/',
 				}),
 				ogImage: fields.image({
 					label: 'OG image override',
 					description:
 						'Optional. Custom social card image (1200×630). Falls back to hero image.',
-					directory: 'public/og',
+					directory: `${repoDir}public/og`,
 					publicPath: '/og/',
 				}),
 				tags: fields.array(fields.text({ label: 'Tag' }), {
@@ -81,7 +95,7 @@ export default config({
 					extension: 'md',
 					options: {
 						image: {
-							directory: 'public/heroes',
+							directory: `${repoDir}public/heroes`,
 							publicPath: '/heroes/',
 						},
 					},
@@ -92,7 +106,7 @@ export default config({
 	singletons: {
 		site: singleton({
 			label: 'Site settings',
-			path: 'src/content/site/',
+			path: `${repoDir}src/content/site/`,
 			schema: {
 				title: fields.text({ label: 'Site title' }),
 				description: fields.text({


### PR DESCRIPTION
## Problem
Deployed `/keystatic` (GitHub mode) showed **no entries**; `/api/keystatic/github/login` 404'd. Two monorepo/setup causes:

1. **Paths.** Keystatic resolves paths relative to **cwd** in local mode (`apps/blog`, works locally) but the **repo root** in GitHub mode. The blog is under `apps/blog/`, so `src/content/blog/*` resolves to nothing at the root → zero entries on prod.
2. **Setup flow.** The "Connect to GitHub" app-creation wizard (`/keystatic/setup`) is only served on **localhost**; a deployed domain dead-ends at a login button until `KEYSTATIC_*` env exist. The old config forced local-filesystem mode on localhost, so the wizard was unreachable.

## Fix
- Prefix repo-relative paths with `apps/blog/` **in GitHub mode only** (collection path, hero/og/content image directories, singleton path). Local stays unprefixed; `publicPath` URLs unchanged.
- Add `PUBLIC_KEYSTATIC_STORAGE=github` override so GitHub mode runs on localhost for the one-time wizard. Read from `import.meta.env` so server + client agree.

Prod behavior without the override env is unchanged (`DEV ? local : github`).

## One-time setup (author action)
1. `PUBLIC_KEYSTATIC_STORAGE=github yarn workspace @portfolio/blog dev`
2. `http://localhost:4321/keystatic/setup` → **Create GitHub App** (Deployed App URL = `https://blog.carnav.in`).
3. Paste generated `KEYSTATIC_GITHUB_CLIENT_ID`, `KEYSTATIC_GITHUB_CLIENT_SECRET`, `KEYSTATIC_SECRET`, `PUBLIC_KEYSTATIC_GITHUB_APP_SLUG` into the blog's Vercel env.
4. Redeploy. Entries list on prod; dashboard commits to `apps/blog/...`.

## Summary by Sourcery

Adjust Keystatic storage configuration and paths to support GitHub-mode dashboard in a monorepo setup.

New Features:
- Allow overriding Keystatic storage mode via a PUBLIC_KEYSTATIC_STORAGE environment variable to force GitHub mode, including on localhost.

Bug Fixes:
- Ensure Keystatic GitHub storage resolves collection and singleton content paths correctly from the monorepo root so entries appear in the deployed dashboard.

Enhancements:
- Unify Keystatic storage resolution between server and client by deriving storage kind from shared environment variables.
- Prefix content and image directories with the app subdirectory only in GitHub storage mode to align with monorepo repository layout.