### PR TITLE
Keystatic: full image support (hero + body) from src/assets

### DIFF
--- a/apps/blog/keystatic.config.ts
+++ b/apps/blog/keystatic.config.ts
@@ -56,8 +56,13 @@ export default config({
 				updatedDate: fields.date({ label: 'Updated date' }),
 				heroImage: fields.image({
 					label: 'Hero image',
-					directory: `${repoDir}public/heroes`,
-					publicPath: '/heroes/',
+					// Stored in src/assets so Astro's image() optimizes it. The
+					// publicPath is relative to the post .md (src/content/blog/*),
+					// matching existing `../../assets/blog/...` hero values so they
+					// render in the editor. Relative path is repo-layout agnostic,
+					// so no repoDir prefix here.
+					directory: `${repoDir}src/assets/blog`,
+					publicPath: '../../assets/blog/',
 				}),
 				ogImage: fields.image({
 					label: 'OG image override',
@@ -94,9 +99,12 @@ export default config({
 					label: 'Content',
 					extension: 'md',
 					options: {
+						// Body images share the hero store: src/assets/blog with a
+						// post-relative publicPath, so existing `![](../../assets/blog/..)`
+						// images show in the editor and new uploads stay Astro-optimized.
 						image: {
-							directory: `${repoDir}public/heroes`,
-							publicPath: '/heroes/',
+							directory: `${repoDir}src/assets/blog`,
+							publicPath: '../../assets/blog/',
 						},
 					},
 				}),


### PR DESCRIPTION
## What

Make the Keystatic dashboard fully support blog images.

Hero and content-image fields were pointed at `public/heroes` (`/heroes/`), which matched **no** existing post, so:
- hero + in-body image previews were blank in the editor;
- a new upload would have written a `/heroes/...` path that Astro's `image()` rejects at build.

## Fix

Point both fields at `src/assets/blog` with a **post-relative** publicPath `../../assets/blog/`:
- Matches existing `../../assets/blog/...` hero and body references → they now render in the editor.
- New uploads land in `src/assets/blog` → stay Astro-optimized (avif/webp, responsive).
- Relative publicPath is repo-layout agnostic (no `apps/blog/` prefix needed); only the storage `directory` carries the monorepo prefix.

OG override is unchanged — it stays in `public/og` with an absolute `/og/` URL, which is correct for social/SEO meta. The earlier monorepo-prefix PR already made the OG directory resolve on prod.

## Not covered

Legacy dev.to imports (`bun`, `common-mistakes`, `nodejs-graphql`) use co-located `./_assets/devto/<slug>/` images. They still render on the site but won't preview in the editor (a Keystatic image field has one directory). Can migrate them to `src/assets/blog` separately if you want full coverage.

Config-only change; site build verified green.

## Summary by Sourcery

Align blog image handling in the Keystatic config with Astro’s asset pipeline so hero and body images stored in src/assets/blog render correctly in the editor and remain optimized.

New Features:
- Enable Keystatic hero image selection and preview from src/assets/blog using post-relative public paths.
- Enable Keystatic body content image uploads and previews from the same src/assets/blog store with matching relative paths.